### PR TITLE
feat(llm): migrate Ollama config to env and refactor summarize pipeline

### DIFF
--- a/.env.local 
+++ b/.env.local 
@@ -1,0 +1,1 @@
+VITE_OLLAMA_URL=http://localhost:11434/api/generate

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,15 +1,20 @@
 import { useState } from 'react';
 import { YouTubeInput } from '../features/youtube/YouTubeInput';
 import { SubtitleFetcher } from '../features/subtitles/SubtitleFetcher';
+import { SummaryViewer } from '../features/llm/SummaryViewer';
 
 export const App = () => {
   const [videoId, setVideoId] = useState<string | null>(null);
+  const [transcript, setTranscript] = useState<string | null>(null);
 
   return (
     <main className="p-8 max-w-2xl mx-auto">
       <h1 className="text-2xl font-bold mb-6">YouTube AI Analyzer</h1>
       <YouTubeInput onSubmit={setVideoId} />
-      {videoId && <SubtitleFetcher videoId={videoId} />}
+      {videoId && (
+        <SubtitleFetcher videoId={videoId} onTranscript={setTranscript} />
+      )}
+      {transcript && <SummaryViewer transcript={transcript} />}
     </main>
   );
 };

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,1 +1,0 @@
-export const API_BASE_URL = 'http://localhost:11434';

--- a/src/config/ollama.ts
+++ b/src/config/ollama.ts
@@ -1,0 +1,1 @@
+export const OLLAMA_URL = import.meta.env.VITE_OLLAMA_URL;

--- a/src/features/llm/SummaryViewer.tsx
+++ b/src/features/llm/SummaryViewer.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect } from 'react';
+import { useSummarize } from './useSummarize';
+
+type Props = {
+  transcript: string;
+};
+
+export const SummaryViewer: React.FC<Props> = ({ transcript }) => {
+  const { summary, loading, error, summarize } = useSummarize();
+
+  useEffect(() => {
+    if (transcript) summarize(transcript);
+  }, [transcript]);
+
+  if (loading) return <p className="text-sm text-gray-500">Summarizing...</p>;
+  if (error) return <p className="text-red-500">Error: {error}</p>;
+  if (!summary) return null;
+
+  return (
+    <div className="mt-6 p-4 border rounded bg-white shadow-sm">
+      <h2 className="text-lg font-semibold mb-2">Summary</h2>
+      <p className="text-sm text-gray-800 whitespace-pre-wrap leading-relaxed">
+        {summary}
+      </p>
+    </div>
+  );
+};

--- a/src/features/llm/generatePrompt.ts
+++ b/src/features/llm/generatePrompt.ts
@@ -1,0 +1,12 @@
+export function buildSummaryPrompt(transcript: string): string {
+  return `
+  You are a world-class content summarization agent, optimized for clarity, context preservation, and readability. 
+  Your task is to generate a clear, concise summary of the following YouTube transcript. Focus on key ideas, logical flow, and eliminating filler. Preserve the structure of the speaker’s argument where possible. Avoid filler and repetition.
+  Return only the final summary. Do not include titles, timestamps, or meta-commentary.
+  
+  ---
+  
+  Transcript:
+  ${transcript}
+  `.trim();
+}

--- a/src/features/llm/index.ts
+++ b/src/features/llm/index.ts
@@ -1,1 +1,4 @@
-// TODO: LLM client (e.g., Ollama integration)
+export * from './SummaryViewer';
+export * from './useSummarize';
+export * from './generatePrompt';
+export * from './llmClient';

--- a/src/features/llm/llmClient.ts
+++ b/src/features/llm/llmClient.ts
@@ -1,0 +1,31 @@
+import { OLLAMA_URL } from '../../config/ollama';
+
+export type LlmRequest = {
+  model: string;
+  prompt: string;
+  stream?: boolean;
+};
+
+export type LlmResponse = {
+  response: string;
+};
+
+export async function callLlm({
+  model,
+  prompt,
+  stream = false,
+}: LlmRequest): Promise<string> {
+  const res = await fetch(OLLAMA_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model, prompt, stream }),
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    throw new Error(`LLM error: ${res.status} ${errorText}`);
+  }
+
+  const data: LlmResponse = await res.json();
+  return data.response;
+}

--- a/src/features/llm/useSummarize.ts
+++ b/src/features/llm/useSummarize.ts
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import { callLlm } from './llmClient';
+import { buildSummaryPrompt } from './generatePrompt';
+
+type Options = {
+  model?: string;
+};
+
+export const useSummarize = () => {
+  const [summary, setSummary] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const summarize = async (transcript: string, options?: Options) => {
+    setLoading(true);
+    setError(null);
+    setSummary(null);
+
+    try {
+      const prompt = buildSummaryPrompt(transcript);
+      const response = await callLlm({
+        model: options?.model || 'mistral',
+        prompt,
+      });
+      setSummary(response.trim());
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { summary, loading, error, summarize };
+};

--- a/src/features/subtitles/SubtitleFetcher.tsx
+++ b/src/features/subtitles/SubtitleFetcher.tsx
@@ -3,14 +3,21 @@ import { useSubtitles } from './useSubtitles';
 
 type Props = {
   videoId: string;
+  onTranscript: (transcript: string | null) => void;
 };
 
-export const SubtitleFetcher: React.FC<Props> = ({ videoId }) => {
+export const SubtitleFetcher: React.FC<Props> = ({ videoId, onTranscript }) => {
   const { loading, transcript, error, fetchSubtitles } = useSubtitles();
 
   useEffect(() => {
     fetchSubtitles(videoId);
   }, [videoId]);
+
+  useEffect(() => {
+    if (transcript) {
+      onTranscript(transcript);
+    }
+  }, [transcript]);
 
   if (loading)
     return <p className="text-sm text-gray-500">Loading subtitles...</p>;

--- a/src/shared/types/global.d.ts
+++ b/src/shared/types/global.d.ts
@@ -1,1 +1,9 @@
 // Global types here
+
+interface ImportMetaEnv {
+  VITE_OLLAMA_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
### ✨ Summary

- Externalized Ollama API endpoint to `.env.local` using `VITE_OLLAMA_URL`
- Added `src/config/ollama.ts` for centralized config management
- Refactored `llmClient`, `generatePrompt`, and `useSummarize` for modularity
- Cleaned up `constants.ts` and moved logic into feature-specific modules
- Updated `SummaryViewer` and `SubtitleFetcher` to work with the new flow

---

### 📦 Why

- Makes the app more portable and production-ready
- Avoids hardcoded API URLs
- Improves LLM summarization pipeline modularity
- Paves the way for supporting multiple LLM backends (e.g. HuggingFace, OpenRouter)

---

### 🧪 How to Test

1. Make sure `ollama serve` is running locally
2. Set up `.env.local` with the correct `VITE_OLLAMA_URL` value  
3. Run the app: `pnpm dev`
4. Load a YouTube video with subtitles
5. Confirm that:
   - Subtitles are fetched and rendered
   - Summary is requested and displayed
   - No hardcoded URLs are used in network traffic
