### PR TITLE
feat: integrate real YouTube subtitles and LLM summarization via Ollama

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "youtube-caption-scraper": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      youtube-caption-scraper:
+        specifier: ^1.0.0
+        version: 1.0.0
     devDependencies:
       '@types/node':
         specifier: ^24.0.3
@@ -712,6 +715,15 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
@@ -905,6 +917,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -956,6 +971,12 @@ packages:
       terser:
         optional: true
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -976,6 +997,9 @@ packages:
     resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  youtube-caption-scraper@1.0.0:
+    resolution: {integrity: sha512-/1bdtPCDxsjVRRQwW+YbxkzRuV36jZvs7imjH++B+QwOWKeCiIY1W4BWnCurTTuCAQ2fF5piuZJd16u6Dw8YWg==}
 
 snapshots:
 
@@ -1570,6 +1594,11 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+    optional: true
+
   node-releases@2.0.19: {}
 
   normalize-path@3.0.0: {}
@@ -1783,6 +1812,9 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tr46@0.0.3:
+    optional: true
+
   ts-interface-checker@0.1.13: {}
 
   typescript@5.8.3: {}
@@ -1806,6 +1838,15 @@ snapshots:
       '@types/node': 24.0.3
       fsevents: 2.3.3
 
+  webidl-conversions@3.0.1:
+    optional: true
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    optional: true
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -1825,3 +1866,9 @@ snapshots:
   yallist@3.1.1: {}
 
   yaml@2.8.0: {}
+
+  youtube-caption-scraper@1.0.0:
+    optionalDependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { YouTubeInput } from '../features/youtube/YouTubeInput';
 import { SubtitleFetcher } from '../features/subtitles/SubtitleFetcher';
 import { SummaryViewer } from '../features/llm/SummaryViewer';

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,20 +1,42 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { YouTubeInput } from '../features/youtube/YouTubeInput';
 import { SubtitleFetcher } from '../features/subtitles/SubtitleFetcher';
 import { SummaryViewer } from '../features/llm/SummaryViewer';
+import { useSummarize } from '../features/llm/useSummarize';
 
 export const App = () => {
   const [videoId, setVideoId] = useState<string | null>(null);
   const [transcript, setTranscript] = useState<string | null>(null);
 
+  const {
+    summary,
+    loading: summarizing,
+    error: summaryError,
+    generateSummary,
+  } = useSummarize();
+
+  const handleTranscript = (text: string | null) => {
+    setTranscript(text);
+    if (text) generateSummary(text);
+  };
+
   return (
     <main className="p-8 max-w-2xl mx-auto">
       <h1 className="text-2xl font-bold mb-6">YouTube AI Analyzer</h1>
+
       <YouTubeInput onSubmit={setVideoId} />
+
       {videoId && (
-        <SubtitleFetcher videoId={videoId} onTranscript={setTranscript} />
+        <SubtitleFetcher videoId={videoId} onTranscript={handleTranscript} />
       )}
-      {transcript && <SummaryViewer transcript={transcript} />}
+
+      {transcript && (
+        <SummaryViewer
+          summary={summary}
+          loading={summarizing}
+          error={summaryError}
+        />
+      )}
     </main>
   );
 };

--- a/src/features/llm/SummaryViewer.tsx
+++ b/src/features/llm/SummaryViewer.tsx
@@ -2,16 +2,12 @@ import React, { useEffect } from 'react';
 import { useSummarize } from './useSummarize';
 
 type Props = {
-  transcript: string;
+  summary: string | null;
+  error: string | null;
+  loading: boolean;
 };
 
-export const SummaryViewer: React.FC<Props> = ({ transcript }) => {
-  const { summary, loading, error, summarize } = useSummarize();
-
-  useEffect(() => {
-    if (transcript) summarize(transcript);
-  }, [transcript]);
-
+export const SummaryViewer: React.FC<Props> = ({ summary, error, loading }) => {
   if (loading) return <p className="text-sm text-gray-500">Summarizing...</p>;
   if (error) return <p className="text-red-500">Error: {error}</p>;
   if (!summary) return null;

--- a/src/features/llm/useSummarize.ts
+++ b/src/features/llm/useSummarize.ts
@@ -11,7 +11,7 @@ export const useSummarize = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const summarize = async (transcript: string, options?: Options) => {
+  const generateSummary = async (transcript: string, options?: Options) => {
     setLoading(true);
     setError(null);
     setSummary(null);
@@ -30,5 +30,5 @@ export const useSummarize = () => {
     }
   };
 
-  return { summary, loading, error, summarize };
+  return { summary, loading, error, generateSummary };
 };

--- a/src/features/subtitles/useSubtitles.ts
+++ b/src/features/subtitles/useSubtitles.ts
@@ -1,24 +1,41 @@
 import { useState } from 'react';
+import { getSubtitles } from 'youtube-caption-scraper';
 
-export const useSubtitles = () => {
-  const [loading, setLoading] = useState(false);
+export function useSubtitles() {
   const [transcript, setTranscript] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const fetchSubtitles = async (videoId: string) => {
     setLoading(true);
     setError(null);
+    setTranscript(null);
+
     try {
-      // TODO: Replace with real API later
-      const mockTranscript = `This is a mock subtitle for video ${videoId}. Replace this with real data.`;
-      await new Promise((res) => setTimeout(res, 1000)); // simulate latency
-      setTranscript(mockTranscript);
-    } catch (e) {
+      const subtitles = await getSubtitles({ videoID: videoId, lang: 'en' });
+
+      if (!Array.isArray(subtitles) || subtitles.length === 0) {
+        setError('No subtitles found for this video.');
+        return;
+      }
+
+      const fullTranscript = subtitles
+        .map((caption) => caption.text.trim())
+        .join(' ');
+
+      setTranscript(fullTranscript);
+    } catch (err) {
+      console.error('[useSubtitles] fetch error:', err);
       setError('Failed to fetch subtitles.');
     } finally {
       setLoading(false);
     }
   };
 
-  return { loading, transcript, error, fetchSubtitles };
-};
+  return {
+    transcript,
+    loading,
+    error,
+    fetchSubtitles,
+  };
+}

--- a/src/types/youtube-caption-scraper.d.ts
+++ b/src/types/youtube-caption-scraper.d.ts
@@ -1,0 +1,6 @@
+declare module 'youtube-caption-scraper' {
+  export function getSubtitles(options: {
+    videoID: string;
+    lang: string;
+  }): Promise<Array<{ text: string }>>;
+}


### PR DESCRIPTION
### ✨ Summary

This PR completes the core flow for YouTube AI Analyzer:

- Fetches real video subtitles via `@extractus/youtube-caption-scraper`
- Sends transcript to a local LLM (via Ollama) for summarization
- Renders the summary in a clean, responsive UI
- Preserves modular architecture: `SubtitleFetcher`, `useSummarize`, `SummaryViewer`

---

### 🧩 Tech Breakdown

- `SubtitleFetcher`: receives `videoId`, fetches captions, returns transcript via callback
- `useSummarize`: handles prompt construction + calling Ollama (via `callLlm`)
- `SummaryViewer`: renders LLM result with loading/error states
- `App.tsx`: manages top-level orchestration of video → transcript → summary

---

### 📦 How to test

1. Set up `.env.local`:
   ```env
   VITE_OLLAMA_URL=http://localhost:11434/api/generate