### PR TITLE
refactor(summary): move Summary component and summarize hook to domai…

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { YouTubeInput } from '../features/youtube/YouTubeInput';
 import { SubtitleFetcher } from '../features/subtitles/SubtitleFetcher';
-import { SummaryViewer } from '../features/llm/SummaryViewer';
-import { useSummarize } from '../features/llm/useSummarize';
+import { Summary } from '../features/summary';
+import { useSummarize } from '../features/summary/useSummarize';
 
 export const App = () => {
   const [videoId, setVideoId] = useState<string | null>(null);
@@ -31,11 +31,7 @@ export const App = () => {
       )}
 
       {transcript && (
-        <SummaryViewer
-          summary={summary}
-          loading={summarizing}
-          error={summaryError}
-        />
+        <Summary summary={summary} loading={summarizing} error={summaryError} />
       )}
     </main>
   );

--- a/src/features/llm/index.ts
+++ b/src/features/llm/index.ts
@@ -1,4 +1,3 @@
-export * from './SummaryViewer';
-export * from './useSummarize';
+export * from '../summary/useSummarize';
 export * from './generatePrompt';
 export * from './llmClient';

--- a/src/features/summary/Summary.tsx
+++ b/src/features/summary/Summary.tsx
@@ -1,13 +1,10 @@
-import React, { useEffect } from 'react';
-import { useSummarize } from './useSummarize';
-
 type Props = {
   summary: string | null;
-  error: string | null;
   loading: boolean;
+  error: string | null;
 };
 
-export const SummaryViewer: React.FC<Props> = ({ summary, error, loading }) => {
+export const Summary: React.FC<Props> = ({ summary, loading, error }) => {
   if (loading) return <p className="text-sm text-gray-500">Summarizing...</p>;
   if (error) return <p className="text-red-500">Error: {error}</p>;
   if (!summary) return null;

--- a/src/features/summary/index.ts
+++ b/src/features/summary/index.ts
@@ -1,1 +1,2 @@
-// TODO: Summary generation logic
+export * from './Summary';
+export * from './useSummarize';

--- a/src/features/summary/useSummarize.ts
+++ b/src/features/summary/useSummarize.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { callLlm } from './llmClient';
-import { buildSummaryPrompt } from './generatePrompt';
+import { callLlm } from '../llm/llmClient';
+import { buildSummaryPrompt } from '../llm/generatePrompt';
 
 type Options = {
   model?: string;


### PR DESCRIPTION
This PR moves the Summary component and the useSummarize hook into the `features/summary` folder to improve feature modularity and cohesion.

Changes:
- Renamed `SummaryViewer.tsx` → `Summary.tsx` and moved it under `features/summary`
- Moved `useSummarize.ts` into the same folder
- Updated all imports to match the new paths

Rationale:
These components are tightly coupled and conceptually belong to the same domain — summarization. Co-locating them makes the architecture easier to navigate and reason about.

No functional changes.