### PR TITLE
chore: add CLAUDE.md and SessionStart hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SessionStart hook: install dependencies when running in a remote Claude Code
+# sandbox (claude.ai/code) so the agent has a working node_modules from the
+# first turn. No-op locally — devs install via `pnpm install` themselves.
+#
+# Toggle: only runs when CLAUDE_CODE_REMOTE=true is set by the runtime.
+
+set -euo pipefail
+
+if [[ "${CLAUDE_CODE_REMOTE:-}" != "true" ]]; then
+  exit 0
+fi
+
+cd "$(dirname "$0")/../.."
+
+# pnpm is required: the lockfile uses pnpm's workspace: protocol, which
+# breaks npm/yarn installs. Bootstrap via corepack when pnpm is missing.
+if ! command -v pnpm >/dev/null 2>&1; then
+  if command -v corepack >/dev/null 2>&1; then
+    echo "[session-start] pnpm not found; enabling via corepack"
+    corepack enable >/dev/null 2>&1 || true
+  fi
+fi
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "[session-start] pnpm unavailable; cannot install dependencies" >&2
+  exit 1
+fi
+
+echo "[session-start] pnpm install --prefer-offline"
+pnpm install --prefer-offline

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+Guidance for Claude Code (and other agentic assistants) working in this repository.
+
+## Project
+
+**YouTube AI Analyzer** — a local-first React SPA that fetches YouTube captions for a given video URL and summarizes the transcript using a locally-running LLM via [Ollama](https://ollama.com/). No backend; all LLM calls go from the browser to `OLLAMA_URL`.
+
+## Stack
+
+- React 18 + TypeScript (strict)
+- Vite 5 build / dev server
+- Tailwind CSS 3 (PostCSS + Autoprefixer)
+- `youtube-caption-scraper` for captions
+- Ollama HTTP API (`/api/generate`) for summarization
+- Package manager: **pnpm**
+
+## Commands
+
+```bash
+pnpm install           # install dependencies
+pnpm dev               # start Vite dev server
+pnpm build             # production build
+pnpm preview           # preview production build
+pnpm exec tsc --noEmit # type-check (no test or lint script defined)
+```
+
+There is no test suite and no linter wired up. `tsc --noEmit` is the closest thing to a lint step — run it before declaring a change done.
+
+## Environment
+
+A `.env.local` is required at the repo root:
+
+```
+VITE_OLLAMA_URL=http://localhost:11434/api/generate
+```
+
+The user must have Ollama running locally with a pulled model (default `mistral`) for the summarize flow to work end-to-end.
+
+## Source layout
+
+```
+src/
+  app/        App.tsx, main.tsx — entry + composition root
+  pages/      Home.tsx (currently unused; App is rendered directly)
+  features/   feature-scoped modules, one folder per domain
+    youtube/    URL input + video-ID extraction
+    subtitles/  caption fetching (useSubtitles hook + component)
+    summary/    summarize hook + Summary component
+    llm/        Ollama client + prompt generation
+  config/     ollama.ts — reads VITE_OLLAMA_URL
+  shared/     cross-feature components, hooks, lib utilities
+  styles/     Tailwind entry (index.css)
+  types/      ambient module declarations
+```
+
+Path alias: `@/*` → `src/*` (configured in both [tsconfig.json](tsconfig.json) and [vite.config.ts](vite.config.ts)).
+
+## Conventions
+
+- **Strict TypeScript** — `strict: true` is on; do not loosen it. Prefer explicit types at module boundaries.
+- **Feature-scoped folders** — each feature owns its hook(s), component(s), and an `index.ts` barrel. New domain logic belongs under `src/features/<name>/`, not in `shared/`.
+- **No backend** — all network calls happen client-side. The Ollama URL is the only external dependency at runtime.
+- **No comments unless the why is non-obvious.** Names should carry intent.
+- **Don't introduce libraries casually** — the dep list is intentionally small. Justify additions in the PR description.
+
+## Notes for agents
+
+- The README mentions Zustand, but it is **not** installed and state is local `useState` in [src/app/App.tsx](src/app/App.tsx). Treat the README as aspirational; the code is the source of truth.
+- `src/pages/Home.tsx` is dead code — `App` is rendered directly from `main.tsx`.
+- When summarizing changes, prefer the file_path:line_number style.


### PR DESCRIPTION
CLAUDE.md documents the stack, commands, env, source layout, and conventions so agents have accurate context from the first turn. The SessionStart hook runs `pnpm install` only when CLAUDE_CODE_REMOTE=true (i.e. inside the claude.ai/code sandbox), bootstrapping pnpm via corepack when needed. Local sessions are unaffected.